### PR TITLE
fix(library.properties): Remove redundant `url` property from library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,6 +8,5 @@ maintainer=IoTeX
 sentence=A W3bstream client for Arduino
 paragraph=The W3bstream Client Arduino Library provides an easy-to-use interface for communicating with the W3bstream network using an Arduino board.
 category=Communication
-url=
 includes=W3bstreamClient.h
 depends=PSACrypto


### PR DESCRIPTION
Previously the [`library.properties` metadata file](https://arduino.github.io/arduino-cli/dev/library-specification/#library-metadata) contained two `url` property definitions. In this case, the later definition overrides the previous one.

The first definition correctly set the property to the repository URL. However, the second one overrode that correct value with an empty value, which caused a rejection of the submission of the library to the Arduino Library Manager registry:

https://github.com/arduino/library-registry/pull/3343#issuecomment-1723385098

> ERROR: library.properties url value is less than minimum length.

The solution is the removal of the invalid redundant `url` property definition, leaving only the correct definition in the file.